### PR TITLE
Add support for Pre-download

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,3 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in cocoapods-multithread-installpod.gemspec
 gemspec
-gem 'cocoapods', '1.0.0'

--- a/cocoapods-multithread-installpod.gemspec
+++ b/cocoapods-multithread-installpod.gemspec
@@ -21,5 +21,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "bundler", "~> 1.6"
   spec.add_dependency "rake"
   spec.add_dependency "cocoapods"
-  spec.add_dependency "thread"
+  spec.add_dependency "concurrent-ruby"
+  spec.add_dependency 'tty-spinner'
 end

--- a/cocoapods-multithread-installpod.gemspec
+++ b/cocoapods-multithread-installpod.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.6"
-  spec.add_development_dependency "rake"
-  spec.add_development_dependency "cocoapods"
-
+  spec.add_dependency "bundler", "~> 1.6"
+  spec.add_dependency "rake"
+  spec.add_dependency "cocoapods"
+  spec.add_dependency "thread"
 end

--- a/lib/cocoapods-multithread-installpod.rb
+++ b/lib/cocoapods-multithread-installpod.rb
@@ -1,121 +1,95 @@
 require "cocoapods-multithread-installpod/version"
-require 'thread'
+require 'thread/pool'
 
-if Pod::VERSION>='0.39.0'
-  module Pod
-    class Installer
-      def install_pod_sources
-        @installed_specs = []
-        pods_to_install = sandbox_state.added | sandbox_state.changed
-        title_options = { :verbose_prefix => '-> '.green }
+module Pod
+  class Installer
+    attr_accessor :worker
+    attr_accessor :todo_workers
+    attr_accessor :doing_workers
 
-        work_q = Queue.new
-        root_specs.sort_by(&:name).each{|spec| work_q.push spec }
-        workers = (0...20).map do
-          Thread.new do
-            begin
-              while spec = work_q.pop(true)
-                if pods_to_install.include?(spec.name)
-                  if sandbox_state.changed.include?(spec.name) && sandbox.manifest
-                    previous = sandbox.manifest.version(spec.name)
-                    title = "Installing #{spec.name} #{spec.version} (was #{previous})"
-                  else
-                    title = "Installing #{spec}"
-                  end
-                  UI.titled_section(title.green, title_options) do
-                    install_source_of_pod(spec.name)
-                    #UI.titled_section("Installed #{spec}", title_options)
-                  end
-                else
-                  UI.titled_section("Using #{spec}", title_options) do
-                    create_pod_installer(spec.name)
-                    #UI.titled_section("Installed #{spec}", title_options)
-                  end
-                end
-              end
-            rescue ThreadError
-            end
-          end
+    alias_method :ori_install_pod_sources, :install_pod_sources
+    def install_pod_sources
+      @worker = Thread.pool(5)
+      @todo_workers = []
+      @doing_workers = []
+      ori_install_pod_sources
+      @worker.shutdown
+      UI.titled_section "All download task completed!"
+    end
+
+    alias_method :ori_install_source_of_pod, :install_source_of_pod
+    def install_source_of_pod(pod_name)
+      @todo_workers << pod_name
+      @worker.process do
+        @todo_workers.delete(pod_name)
+        @doing_workers << pod_name
+        ori_install_source_of_pod(pod_name)
+        @doing_workers.delete(pod_name)
+        UI.titled_section "Download completed: #{pod_name} (Remain Doing: #{@doing_workers.count} Waiting: #{@todo_workers.count})"
+      end
+    end
+
+    class Analyzer
+      attr_accessor :worker
+      attr_accessor :todo_workers
+      attr_accessor :doing_workers
+
+      alias_method :ori_fetch_external_sources, :fetch_external_sources
+      def fetch_external_sources
+        @worker = Thread.pool(5)
+        @todo_workers = []
+        @doing_workers = []
+        ori_fetch_external_sources
+        @worker.shutdown
+        UI.titled_section "All download task completed!"
+      end
+
+      alias_method :ori_fetch_external_source, :fetch_external_source
+      def fetch_external_source(dependency, use_lockfile_options)
+        @todo_workers << dependency.name
+        @worker.process do
+          @todo_workers.delete(dependency.name)
+          @doing_workers << dependency.name
+          ori_fetch_external_source(dependency, use_lockfile_options)
+          @doing_workers.delete(dependency.name)
+          UI.titled_section "Download completed: #{dependency.name} (Remain Doing: #{@doing_workers.count} Waiting: #{@todo_workers.count})"
         end
-        UI.titled_section("Installing... Please Wait...", title_options)
-        workers.map(&:join)
       end
     end
 
 
-    module Downloader
-      # The class responsible for managing Pod downloads, transparently caching
-      # them in a cache directory.
-      #
-      class Cache
-        @@mutex=Mutex.new
-        def ensure_matching_version
-          @@mutex.lock
-          version_file = root + 'VERSION'
-          version = version_file.read.strip if version_file.file?
-
-          root.rmtree if version != Pod::VERSION && root.exist?
-          root.mkpath
-          version_file.open('w') { |f| f << Pod::VERSION }
-          @@mutex.unlock
+    class PodSourcePreparer
+      # Remove Dir.chidr to ensure thread safety.
+      alias_method :ori_run_prepare_command, :run_prepare_command
+      def run_prepare_command
+        return unless spec.prepare_command
+        UI.section(' > Running prepare command', '', 1) do
+          begin
+            ENV.delete('CDPATH')
+            ENV['COCOAPODS_VERSION'] = Pod::VERSION
+            prepare_command = spec.prepare_command.strip_heredoc.chomp
+            full_command = "cd \"#{path}\"\nset -e\n" + prepare_command
+            bash!('-c', full_command)
+          ensure
+            ENV.delete('COCOAPODS_VERSION')
+          end
         end
       end
     end
   end
 
-elsif Pod::VERSION=='0.35.0'
-  module Pod
-    class Installer
-      def install_pod_sources
-        @installed_specs = []
-        pods_to_install = sandbox_state.added | sandbox_state.changed
-        title_options = { :verbose_prefix => '-> '.green }
-        sorted_root_specs = root_specs.sort_by(&:name)
-        threads=[]
-        max_thread_count = 20.0
-        per_thead_task_count =(sorted_root_specs.count/max_thread_count).ceil
-        i = 0
-        while i < max_thread_count
-          sub_sorted_root_specs = sorted_root_specs[i*per_thead_task_count, per_thead_task_count]
-          if sub_sorted_root_specs != nil
-            threads << Thread.new(sub_sorted_root_specs) do |specs|
-              specs.each do |spec|
-                if pods_to_install.include?(spec.name)
-                  if sandbox_state.changed.include?(spec.name) && sandbox.manifest
-                    previous = sandbox.manifest.version(spec.name)
-                    title = "Installing #{spec.name} #{spec.version} (was #{previous})"
-                  else
-                    title = "Installing #{spec}"
-                  end
-                  UI.titled_section(title.green, title_options) do
-                    install_source_of_pod(spec.name)
-                  end
-                else
-                  UI.titled_section("Using #{spec}", title_options)
-                end
-              end
-            end
-          end
-          i+=1
-        end
-        threads.each{|t| t.join}
-      end
-    end
-
-    module UserInterface
-      class << self
-        def wrap_string(string, indent = 0)
-          if disable_wrap
-            string
-          else
-            first_space = ' ' * indent
-            # indented = CLAide::Helper.wrap_with_indent(string, indent, 9999)
-            # first_space + indented
-          end
-        end
+  module Downloader
+    # The class responsible for managing Pod downloads, transparently caching
+    # them in a cache directory.
+    #
+    class Cache
+      @@mutex=Mutex.new
+      alias_method :ori_ensure_matching_version, :ensure_matching_version
+      def ensure_matching_version
+        @@mutex.lock
+        ori_ensure_matching_version
+        @@mutex.unlock
       end
     end
   end
 end
-
-

--- a/lib/cocoapods-multithread-installpod.rb
+++ b/lib/cocoapods-multithread-installpod.rb
@@ -1,94 +1,68 @@
 require "cocoapods-multithread-installpod/version"
-require 'thread/pool'
+require 'concurrent'
 
 module Pod
   class Installer
-    attr_accessor :worker
-    attr_accessor :todo_workers
-    attr_accessor :doing_workers
 
-    alias_method :ori_install_pod_sources, :install_pod_sources
+    alias_method :multi_thread_install_pod_sources, :install_pod_sources
     def install_pod_sources
-      @worker = Thread.pool(5)
-      @todo_workers = []
-      @doing_workers = []
-      ori_install_pod_sources
-      @worker.shutdown
-      UI.titled_section "All download task completed!"
-    end
-
-    alias_method :ori_install_source_of_pod, :install_source_of_pod
-    def install_source_of_pod(pod_name)
-      @todo_workers << pod_name
-      @worker.process do
-        @todo_workers.delete(pod_name)
-        @doing_workers << pod_name
-        ori_install_source_of_pod(pod_name)
-        @doing_workers.delete(pod_name)
-        UI.titled_section "Download completed: #{pod_name} (Remain Doing: #{@doing_workers.count} Waiting: #{@todo_workers.count})"
+      @worker = Concurrent::FixedThreadPool.new(5)
+      UI.set_spinners('Downloading dependencies')
+      @installed_specs = []
+      pods_to_install = sandbox_state.added | sandbox_state.changed
+      title_options = { :verbose_prefix => '-> '.green }
+      root_specs.sort_by(&:name).each do |spec|
+        if pods_to_install.include?(spec.name)
+          @worker.post do
+            if sandbox_state.changed.include?(spec.name) && sandbox.manifest
+              current_version = spec.version
+              previous_version = sandbox.manifest.version(spec.name)
+              has_changed_version = current_version != previous_version
+              current_repo = analysis_result.specs_by_source.detect { |key, values| break key if values.map(&:name).include?(spec.name) }
+              current_repo &&= current_repo.url || current_repo.name
+              previous_spec_repo = sandbox.manifest.spec_repo(spec.name)
+              has_changed_repo = !previous_spec_repo.nil? && current_repo && !current_repo.casecmp(previous_spec_repo).zero?
+              title = "Installing #{spec.name} #{spec.version}"
+              title << " (was #{previous_version} and source changed to `#{current_repo}` from `#{previous_spec_repo}`)" if has_changed_version && has_changed_repo
+              title << " (was #{previous_version})" if has_changed_version && !has_changed_repo
+              title << " (source changed to `#{current_repo}` from `#{previous_spec_repo}`)" if !has_changed_version && has_changed_repo
+            else
+              title = "Installing #{spec}"
+            end
+            UI.titled_section(title.green, title_options) do
+              install_source_of_pod(spec.name)
+            end
+            UI.report_status(true)
+          end
+        else
+          UI.titled_section("Using #{spec}", title_options) do
+            create_pod_installer(spec.name)
+          end
+        end
       end
+      @worker.shutdown
+      @worker.wait_for_termination
+      UI.set_spinners
     end
 
     class Analyzer
-      attr_accessor :worker
-      attr_accessor :todo_workers
-      attr_accessor :doing_workers
 
       alias_method :ori_fetch_external_sources, :fetch_external_sources
-      def fetch_external_sources
-        @worker = Thread.pool(5)
-        @todo_workers = []
-        @doing_workers = []
-        ori_fetch_external_sources
+      def fetch_external_sources(podfile_state)
+        @worker = Concurrent::FixedThreadPool.new(5)
+        UI.set_spinners('Fetching external sources')
+        ori_fetch_external_sources(podfile_state)
         @worker.shutdown
-        UI.titled_section "All download task completed!"
+        @worker.wait_for_termination
+        UI.set_spinners
       end
 
       alias_method :ori_fetch_external_source, :fetch_external_source
       def fetch_external_source(dependency, use_lockfile_options)
-        @todo_workers << dependency.name
-        @worker.process do
-          @todo_workers.delete(dependency.name)
-          @doing_workers << dependency.name
+        @worker.post do
           ori_fetch_external_source(dependency, use_lockfile_options)
-          @doing_workers.delete(dependency.name)
-          UI.titled_section "Download completed: #{dependency.name} (Remain Doing: #{@doing_workers.count} Waiting: #{@todo_workers.count})"
+          UI.report_status(true)
         end
-      end
-    end
-
-
-    class PodSourcePreparer
-      # Remove Dir.chidr to ensure thread safety.
-      alias_method :ori_run_prepare_command, :run_prepare_command
-      def run_prepare_command
-        return unless spec.prepare_command
-        UI.section(' > Running prepare command', '', 1) do
-          begin
-            ENV.delete('CDPATH')
-            ENV['COCOAPODS_VERSION'] = Pod::VERSION
-            prepare_command = spec.prepare_command.strip_heredoc.chomp
-            full_command = "cd \"#{path}\"\nset -e\n" + prepare_command
-            bash!('-c', full_command)
-          ensure
-            ENV.delete('COCOAPODS_VERSION')
-          end
-        end
-      end
-    end
-  end
-
-  module Downloader
-    # The class responsible for managing Pod downloads, transparently caching
-    # them in a cache directory.
-    #
-    class Cache
-      @@mutex=Mutex.new
-      alias_method :ori_ensure_matching_version, :ensure_matching_version
-      def ensure_matching_version
-        @@mutex.lock
-        ori_ensure_matching_version
-        @@mutex.unlock
       end
     end
   end

--- a/lib/cocoapods-multithread-installpod/version.rb
+++ b/lib/cocoapods-multithread-installpod/version.rb
@@ -1,3 +1,3 @@
 module CocoapodsMultithreadInstallpod
-  VERSION = "0.0.8"
+  VERSION = "0.0.9"
 end

--- a/lib/cocoapods_plugin.rb
+++ b/lib/cocoapods_plugin.rb
@@ -1,1 +1,14 @@
-require 'cocoapods-multithread-installpod.rb'
+
+module Pod
+  class Installer
+    alias_method :multi_thread_install_0712!, :install!
+    def install!
+      unless config.verbose?
+          require 'multi_thread_log.rb'
+          require 'thread_safe_hook.rb'
+          require 'cocoapods-multithread-installpod.rb'
+      end
+      multi_thread_install_0712!
+    end
+  end
+end

--- a/lib/multi_thread_log.rb
+++ b/lib/multi_thread_log.rb
@@ -1,0 +1,59 @@
+require 'tty-spinner'
+
+module Pod
+    module UserInterface
+
+        class << self
+            @@spinners = nil
+            @@spinner_map = {}
+            @@my_mutex = Mutex.new
+
+            alias_method :multi_thread_titled_section, :titled_section
+            def titled_section(title, options = {})
+                # 为了缩短 Pre-downloading 和 Fetching podspec 的文字长度，防止log出现换行而错乱
+                if title =~ /(Pre-downloading: `.+?`) .*/ ||
+                    title =~ /(Fetching podspec for `.+?`) .*/
+                    title = $1
+                end
+                if block_given?
+                    multi_thread_titled_section(title, options, &Proc.new)
+                else
+                    multi_thread_titled_section(title, options)
+                end
+            end
+
+            alias :pod_puts_0706 :puts
+            def puts(message = '')
+                mainThread = Thread.main == Thread.current
+                thread_id = Thread.current.object_id
+                message = message.join if message.is_a? Array
+                @@my_mutex.synchronize do
+                    spinner = @@spinner_map[thread_id]
+                    if !mainThread && @@spinners && spinner.nil?
+                        spinner = @@spinners.register "[:spinner] #{message}"
+                        spinner.auto_spin
+                        @@spinner_map[thread_id] = spinner
+                    else
+                        pod_puts_0706(message)
+                    end
+                end
+            end
+
+            def set_spinners(title=nil)
+                @@my_mutex.synchronize do
+                    @@spinners = title.nil? ? nil : TTY::Spinner::Multi.new
+                end
+            end
+
+            def report_status(status)
+                thread_id = Thread.current.object_id
+                @@my_mutex.synchronize do
+                    spinner = @@spinner_map.delete thread_id
+                    unless spinner.nil?
+                        spinner.success
+                    end
+                end
+            end
+        end
+    end
+end

--- a/lib/thread_safe_hook.rb
+++ b/lib/thread_safe_hook.rb
@@ -1,0 +1,48 @@
+require 'cocoapods'
+
+module Pod
+  class Installer
+    class PodSourcePreparer
+      # Remove Dir.chidr to ensure thread safety.
+      alias_method :ori_run_prepare_command, :run_prepare_command
+      def run_prepare_command
+        return unless spec.prepare_command
+        UI.section(' > Running prepare command', '', 1) do
+          begin
+            ENV.delete('CDPATH')
+            ENV['COCOAPODS_VERSION'] = Pod::VERSION
+            prepare_command = spec.prepare_command.strip_heredoc.chomp
+            full_command = "cd \"#{path}\"\nset -e\n" + prepare_command
+            bash!('-c', full_command)
+          ensure
+            ENV.delete('COCOAPODS_VERSION')
+          end
+        end
+      end
+    end
+  end
+
+  class Specification
+    class << self
+      @@my_mutex = Mutex.new
+      alias_method :pod_from_string_0712, :from_string
+      def from_string(spec_contents, path, subspec_name = nil)
+        @@my_mutex.synchronize do
+          pod_from_string_0712(spec_contents, path, subspec_name)
+        end
+      end
+    end
+  end
+
+  module Downloader
+    class Cache
+      @@mutex=Mutex.new
+      alias_method :ori_ensure_matching_version, :ensure_matching_version
+      def ensure_matching_version
+        @@mutex.lock
+        ori_ensure_matching_version
+        @@mutex.unlock
+      end
+    end
+  end
+end


### PR DESCRIPTION
减少代码覆盖，使用线程池方式调用原始函数；
增加 Pre Download 多线程支持；
减少并发数为5个（原本20个）（感觉变化不是很明显）
修复 podspec 中带有 prepare_command 多线程下，Dir.chdir 有线程安全问题